### PR TITLE
🔧 fix(pages-build-integration.yml): use logical OR operator for MKDOC…

### DIFF
--- a/.github/workflows/pages-build-integration.yml
+++ b/.github/workflows/pages-build-integration.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Build Docs
         env:
-          MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.PAT | secrets.GITHUB_TOKEN }}
+          MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
…S_GIT_COMMITTERS_APIKEY to ensure fallback to GITHUB_TOKEN if PAT is not available