### PR TITLE
🐛 fix(terraform.tfvars): correct syntax errors in IBM and OCI terrafo…

### DIFF
--- a/ibm/6.4/single/terraform.tfvars
+++ b/ibm/6.4/single/terraform.tfvars
@@ -1,3 +1,3 @@
 ibmcloud_api_key      = "<IBM cloud API Key>"
-iaas_classic_username = "<IBM classic username>
+iaas_classic_username = "<IBM classic username>"
 iaas_classic_api_key  = "<IBM classic API Key>"

--- a/oci/6.2/ha/terraform.tfvars
+++ b/oci/6.2/ha/terraform.tfvars
@@ -3,4 +3,4 @@ tenancy_ocid     = "ocid1.tenancy.oc1..<REST OF YOUR TENANCY ID>"
 compartment_ocid = "ocid1.compartment.oc1..<REST OF YOUR COMPARTMENT ID>"
 user_ocid        = "ocid1.user.oc1..<REST OF YOUR USER ID>"
 private_key_path = "oci_api_key.pem"
-region           = "<OCI REGION>
+region           = "<OCI REGION>"


### PR DESCRIPTION
…rm variable files by adding missing closing quotes to ensure proper string declaration